### PR TITLE
Enchant preservation for accursed items

### DIFF
--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
@@ -8,4 +8,6 @@ kill @e[type=item,tag=stellarity.aota.netherite_pickaxe,distance=..1.5,limit=1]
 loot spawn ~ ~.1 ~ loot stellarity:items/tools/hematic_pickaxe
 tag @n[type=item] add stellarity.aota.skip
 
+data modify entity @n[type=item] Item.components."minecraft:enchantments" set from storage stellarity:temp aota.enchants
+
 function stellarity:mechanics/altar_of_accursed/crafting/global_effects

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
@@ -1,3 +1,6 @@
+data modify storage stellarity:temp aota.item set from entity @e[type=item,tag=stellarity.aota.netherite_pickaxe,distance=..1.5,limit=1] Item.components
+data modify storage stellarity:temp aota.enchants set from storage stellarity:temp aota.item."minecraft:enchantments"
+
 kill @e[type=item,tag=stellarity.aota.enderite_smithing_template,distance=..1.5,limit=1]
 kill @e[type=item,tag=stellarity.aota.living_flesh,distance=..1.5,limit=1]
 kill @e[type=item,tag=stellarity.aota.netherite_pickaxe,distance=..1.5,limit=1]

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
@@ -8,4 +8,6 @@ kill @e[type=item,tag=stellarity.aota.3_diamonds,distance=..1.5,limit=1]
 loot spawn ~ ~.1 ~ loot stellarity:items/spectral_fury
 tag @n[type=item] add stellarity.aota.skip
 
+data modify entity @n[type=item] Item.components."minecraft:enchantments" set from storage stellarity:temp aota.enchants
+
 function stellarity:mechanics/altar_of_accursed/crafting/global_effects

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
@@ -1,3 +1,6 @@
+data modify storage stellarity:temp aota.item set from entity @e[type=item,tag=stellarity.aota.sharanga,distance=..1.5,limit=1] Item.components
+data modify storage stellarity:temp aota.enchants set from storage stellarity:temp aota.item."minecraft:enchantments"
+
 kill @e[type=item,tag=stellarity.aota.sharanga,distance=..1.5,limit=1]
 kill @e[type=item,tag=stellarity.aota.8_membranes,distance=..1.5,limit=1]
 kill @e[type=item,tag=stellarity.aota.3_diamonds,distance=..1.5,limit=1]


### PR DESCRIPTION
Adds the enchant preservation check to the remaining enchantable items you can craft with the altar of the accursed.