### PR TITLE
(actually) fix the enchant preservation of items

### DIFF
--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/call_of_the_void.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/call_of_the_void.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.bow,distance=..1.5] Item.components
+data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.minecraft.bow,distance=..1.5] Item.components
 data modify storage stellarity:temp aota.enchants set from storage stellarity:temp aota.item."minecraft:enchantments"
 
 loot spawn ~ ~.1 ~ loot stellarity:items/call_of_the_void

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/hematic_pickaxe.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.netherite_pickaxe,distance=..1.5] Item.components
+data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_pickaxe,distance=..1.5] Item.components
 data modify storage stellarity:temp aota.enchants set from storage stellarity:temp aota.item."minecraft:enchantments"
 
 loot spawn ~ ~.1 ~ loot stellarity:items/tools/hematic_pickaxe

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/items/spectral_fury.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.sharanga,distance=..1.5] Item.components
+data modify storage stellarity:temp aota.item set from entity @n[type=item,tag=stellarity.aota.stellarity.sharanga,distance=..1.5] Item.components
 data modify storage stellarity:temp aota.enchants set from storage stellarity:temp aota.item."minecraft:enchantments"
 
 loot spawn ~ ~.1 ~ loot stellarity:items/spectral_fury

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/axe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/axe.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.netherite_axe,distance=..1.5] Item.components."minecraft:enchantments"
+data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_axe,distance=..1.5] Item.components."minecraft:enchantments"
 
 loot spawn ~ ~-.4 ~ loot stellarity:items/tools/shulker/axe
 

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/hoe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/hoe.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.netherite_hoe,distance=..1.5] Item.components."minecraft:enchantments"
+data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_hoe,distance=..1.5] Item.components."minecraft:enchantments"
 
 loot spawn ~ ~-.4 ~ loot stellarity:items/tools/shulker/hoe
 

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/pickaxe.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/pickaxe.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.netherite_pickaxe,distance=..1.5] Item.components."minecraft:enchantments"
+data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_pickaxe,distance=..1.5] Item.components."minecraft:enchantments"
 
 loot spawn ~ ~-.4 ~ loot stellarity:items/tools/shulker/pickaxe
 

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/shovel.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/shovel.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.netherite_shovel,distance=..1.5] Item.components."minecraft:enchantments"
+data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_shovel,distance=..1.5] Item.components."minecraft:enchantments"
 
 loot spawn ~ ~-.4 ~ loot stellarity:items/tools/shulker/shovel
 

--- a/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/sword.mcfunction
+++ b/data/stellarity/function/mechanics/altar_of_accursed/crafting/shulker_tools/sword.mcfunction
@@ -1,4 +1,4 @@
-data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.netherite_sword,distance=..1.5] Item.components."minecraft:enchantments"
+data modify storage stellarity:temp aota.enchants set from entity @n[type=item,tag=stellarity.aota.minecraft.netherite_sword,distance=..1.5] Item.components."minecraft:enchantments"
 
 loot spawn ~ ~-.4 ~ loot stellarity:items/tools/shulker/sword
 


### PR DESCRIPTION
Turns out it was as simple as some items just missing the `minecraft` or `stellarity` part of the ingredient item's tag. I would've noticed this if i checked the storage tbh.